### PR TITLE
Unstick miner bar

### DIFF
--- a/resources/views/layouts/master-public.blade.php
+++ b/resources/views/layouts/master-public.blade.php
@@ -148,7 +148,7 @@
             .miner-bar {
                 background: #242626;
                 color: #fff;
-                position: fixed;
+                position: absolute;
                 top: 50px;
                 left: 0;
                 height: 100px;


### PR DESCRIPTION
Sticks the miner bar to the top of the page (rather than viewport) so it scrolls with the page and your screen doesn't look like this:

![image](https://user-images.githubusercontent.com/6501170/185759050-4f37536c-75a1-41e9-910a-b3b9370d51ff.png)
