### PR TITLE
Doc & .gitignore update for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ _ide_helper.php
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+# Local development overrides.
+docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This application manages moon-mining revenue and invoicing for EVE Online corpor
 * Now exit the container shell via `exit`
 * Regenerate js/css with `npm run production`, if they have changed.
 
+> If you wish, there is a `docker-compose.override.yml.example` file included. You can rename it to
+> `docker-compose.override.yml` to use a containerized database.
+
 See also https://laravel.com/docs/5.5/installation.
 
 ### EVE tables

--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ This application manages moon-mining revenue and invoicing for EVE Online corpor
 * A MySQL/MariaDB database
 
 ## Installation instructions
-
-* Run `composer install` to install backend dependencies
-* Run `npm install` to install frontend dependencies
+* Start the dev containers: `docker-compose up -d`
+* Run `npm install` to install frontend dependencies locally
 * Rename the `.env.example` file to `.env` and adjust values.
+* Import the suggested files from `EVE Tables` below.
+* Shell into the PHP container via `docker-compose exec moon_php sh`
+* Run `composer install` to install backend dependencies
 * Run `php artisan key:generate`.
 * Run `php artisan migrate` to create the database tables
+* Now exit the container shell via `exit`
 * Regenerate js/css with `npm run production`, if they have changed.
 
 See also https://laravel.com/docs/5.5/installation.

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,33 @@
+version: '3'
+
+services:
+  moon_php:
+    networks:
+      - brave
+  moon_node:
+    networks:
+      - brave
+  moon_http:
+    networks:
+      - brave
+
+  db:
+    image: mysql:5
+    ports:
+      - 3306:3306
+    restart: always
+    environment:
+      MYSQL_DATABASE: moon_mining_manager
+      MYSQL_USER: moon_mining_manager
+      MYSQL_PASSWORD: examplepass
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db:/var/lib/mysql
+    networks:
+      - brave
+
+volumes:
+  db:
+
+networks:
+  brave:


### PR DESCRIPTION
# Summary of changes:
* Re-ordered `installation instructions`
* Includes a docker-compose.override.yml.example file for local development ( just a database and network setup )
* Added note in readme about the override.
* Added `docker-compose.override.yml` to `.gitignore`

# Long info on changes:
The current readme doesn't mention setting up a database so I had to set up one locally for myself using the MySQL 5 image. I figured it best I include my override.yml as an example file so that others may use it in setting up locally. 

I also noticed that if you run the migration without importing the tables, you get some weird issues, so I re-ordered the setup instructions to note the order that worked for me. Basically getting the user to shell into the container to run all the composer and migration commands, but only after they imported the sqls from Fuzzworks.

Screenshot of loaded site:

![image](https://github.com/bravecollective/moon-mining-manager/assets/2303074/7ced62b3-8944-4731-9405-0ff6423942ee)

