### PR TITLE
convert rentals from individual->active, corporation->passive (no db …

### DIFF
--- a/app/Classes/CalculateRent.php
+++ b/app/Classes/CalculateRent.php
@@ -29,9 +29,9 @@ class CalculateRent
         }
 
         // Save the updated rental fee.
-        if ($contractType === Renter::TYPE_CORPORATION) {
+        if ($contractType === Renter::TYPE_PASSIVE) {
             $moon->monthly_corp_rental_fee = $fee;
-        } else { // Renter::TYPE_INDIVIDUAL
+        } else { // Renter::TYPE_ACTIVE
             $moon->monthly_rental_fee = $fee;
         }
         $moon->save();
@@ -77,8 +77,8 @@ class CalculateRent
                     break;
             }
 
-            // Reduce rent for corporations by 30%
-            $taxRate *= $contractType === Renter::TYPE_CORPORATION ? 0.7 : 1;
+            // Increase rent for passive renters
+            $taxRate *= ($contractType === Renter::TYPE_ACTIVE)? 1 : 1.62;
 
             // Reduce moon value to 70% for rent calculation
             $moonValue = $oreValue * $units * 0.7;

--- a/app/Http/Controllers/MoonAdminController.php
+++ b/app/Http/Controllers/MoonAdminController.php
@@ -296,8 +296,8 @@ class MoonAdminController extends Controller
         // Grab all of the (available) moons and loop through them.
         $moons = Moon::where('available', 1)->get();
         foreach ($moons as $moon) {
-            $calc->updateMoon($moon, Renter::TYPE_INDIVIDUAL);
-            $calc->updateMoon($moon, Renter::TYPE_CORPORATION);
+            $calc->updateMoon($moon, Renter::TYPE_ACTIVE);
+            $calc->updateMoon($moon, Renter::TYPE_PASSIVE);
         }
 
         // Redirect back to admin.

--- a/app/Http/Controllers/RenterController.php
+++ b/app/Http/Controllers/RenterController.php
@@ -273,7 +273,7 @@ class RenterController extends Controller
 
     private function populateDataAndSave(Renter $renter, $request)
     {
-        $renter->type = $request->type == Renter::TYPE_CORPORATION ? Renter::TYPE_CORPORATION : Renter::TYPE_INDIVIDUAL;
+        $renter->type = ($request->type == Renter::TYPE_ACTIVE)? Renter::TYPE_ACTIVE : Renter::TYPE_PASSIVE;
         $renter->character_id = $request->character_id;
         $renter->character_name = $this->getName($renter->character_id);
         $renter->refinery_id = $request->refinery_id;

--- a/app/Jobs/CalculateRent.php
+++ b/app/Jobs/CalculateRent.php
@@ -35,19 +35,19 @@ class CalculateRent implements ShouldQueue
             $moon->previous_monthly_corp_rental_fee = $moon->monthly_corp_rental_fee;
 
             // update - saves the $moon object
-            $fee = $calc->updateMoon($moon, Renter::TYPE_INDIVIDUAL);
-            $corpFee = $calc->updateMoon($moon, Renter::TYPE_CORPORATION);
+            $fee = $calc->updateMoon($moon, Renter::TYPE_ACTIVE);
+            $corpFee = $calc->updateMoon($moon, Renter::TYPE_PASSIVE);
 
             Log::info("CalculateRent: updated stored monthly rental fee for moon $moon->id to $fee/$corpFee");
 
             // Update the monthly rent figure if this moon is currently rented.
             DB::table('renters')
                 ->where('moon_id', $moon->id)
-                ->where('type', Renter::TYPE_INDIVIDUAL)
+                ->where('type', Renter::TYPE_ACTIVE)
                 ->update(['monthly_rental_fee' => $fee]);
             DB::table('renters')
                 ->where('moon_id', $moon->id)
-                ->where('type', Renter::TYPE_CORPORATION)
+                ->where('type', Renter::TYPE_PASSIVE)
                 ->update(['monthly_rental_fee' => $corpFee]);
         }
     }

--- a/app/Models/Renter.php
+++ b/app/Models/Renter.php
@@ -47,9 +47,9 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Renter extends Model
 {
-    const TYPE_INDIVIDUAL = 'individual';
+    const TYPE_ACTIVE = 'individual';
 
-    const TYPE_CORPORATION = 'corporation';
+    const TYPE_PASSIVE = 'corporation';
 
     protected $table = 'renters';
 

--- a/resources/views/moons/list.blade.php
+++ b/resources/views/moons/list.blade.php
@@ -18,8 +18,8 @@
                         <th>Mineral composition</th>
                         <th>Total %</th>
                         <th class="numeric">
-                            Monthly fee<br>
-                            Corp fee
+                            Active fee<br>
+                            Passive fee
                         </th>
                         <th class="numeric">Last month</th>
                         <th>Renter</th>

--- a/resources/views/moons/list.blade.php
+++ b/resources/views/moons/list.blade.php
@@ -71,7 +71,7 @@
                                 {{ $moon->active_renter ? $moon->active_renter->character_name : '' }}
                             </td>
                             <td>
-                                {{ $moon->active_renter ? $moon->active_renter->type : '' }}
+                                {{ $moon->active_renter ? ($moon->active_renter->type === 'individual')? 'active' : 'passive' : '' }}
                             </td>
                             <td class="moon-status"
                                 data-moon-id="{{ $moon->id }}"

--- a/resources/views/moons/public.blade.php
+++ b/resources/views/moons/public.blade.php
@@ -36,8 +36,8 @@
                     <th>Mineral #3</th>
                     <th>Mineral #4</th>
                     <th>Total %</th>
-                    <th class="numeric">Rent (Individuals)</th>
-                    <th class="numeric">Rent (Corporations)</th>
+                    <th class="numeric">Rent (Active)</th>
+                    <th class="numeric">Rent (Passive)</th>
                     <th>Status</th>
                 </tr>
             </thead>

--- a/resources/views/renters/edit.blade.php
+++ b/resources/views/renters/edit.blade.php
@@ -31,13 +31,13 @@
                     <div>
                         <label for="type">Type of rental</label>
                         <select id="type" name="type">
-                            <option value="{{\App\Models\Renter::TYPE_INDIVIDUAL}}"
-                                    {{ ($renter->type == \App\Models\Renter::TYPE_INDIVIDUAL) ? ' selected' : '' }}>
-                                Individual
+                            <option value="{{\App\Models\Renter::TYPE_ACTIVE}}"
+                                    {{ ($renter->type == \App\Models\Renter::TYPE_ACTIVE) ? ' selected' : '' }}>
+                                Active
                             </option>
-                            <option value="{{\App\Models\Renter::TYPE_CORPORATION}}"
-                                    {{ ($renter->type == \App\Models\Renter::TYPE_CORPORATION) ? ' selected' : '' }}>
-                                Corporation
+                            <option value="{{\App\Models\Renter::TYPE_PASSIVE}}"
+                                    {{ ($renter->type == \App\Models\Renter::TYPE_PASSIVE) ? ' selected' : '' }}>
+                                Passive
                             </option>
                         </select>
                     </div>

--- a/resources/views/renters/home.blade.php
+++ b/resources/views/renters/home.blade.php
@@ -63,7 +63,7 @@
                                     {{ $renter->character_name ? $renter->character_name : '[missing name]' }}
                                 </a>
                             </td>
-                            <td>{{ $renter->type }}</td>
+                            <td>{{ ($renter->type === 'individual')? 'active' : 'passive' }}</td>
                             <td>{{ $renter->notes }}</td>
                             <td class="numeric">{{ number_format($renter->monthly_rental_fee, 0) }}</td>
                             <td class="numeric">{{ number_format($renter->amount_owed, 0) }}</td>

--- a/resources/views/renters/new.blade.php
+++ b/resources/views/renters/new.blade.php
@@ -31,8 +31,8 @@
                     <div>
                         <label for="type">Type of rental</label>
                         <select id="type" name="type" onchange="updateFee()">
-                            <option value="{{\App\Models\Renter::TYPE_INDIVIDUAL}}">Individual</option>
-                            <option value="{{\App\Models\Renter::TYPE_CORPORATION}}">Corporation</option>
+                            <option value="{{\App\Models\Renter::TYPE_ACTIVE}}">Active</option>
+                            <option value="{{\App\Models\Renter::TYPE_PASSIVE}}">Passive</option>
                         </select>
                     </div>
                     <div>


### PR DESCRIPTION
Resolve #34 

Rename in the ui individual -> active and corporation -> passive rental types.

This does not alter the database enumeration

example tax rates before:
![image](https://github.com/user-attachments/assets/9843970c-870e-414b-a5de-2627644b85f4)
after:
![image](https://github.com/user-attachments/assets/0509265f-81cf-4ccb-9739-ece5f0442fe8)

Note that this does not include the 50m flat discount for r4-only moons (PR #38)