### PR TITLE
fix(miners): allow empty alliance / corp in .env

### DIFF
--- a/app/Http/Controllers/AppController.php
+++ b/app/Http/Controllers/AppController.php
@@ -85,7 +85,8 @@ class AppController extends Controller
             'top_miner' => (isset($top_miner)) ? $top_miner : null,
             'top_refinery' => (isset($top_refinery)) ? $top_refinery : null,
             'top_system' => (isset($top_system)) ? $top_system : null,
-            'miners' => Miner::where('amount_owed', '>=', 1)->whereRaw($whitelist_whereRaw)
+            'miners' => Miner::where('amount_owed', '>=', 1)
+                ->when($whitelist_whereRaw, fn($q) => $q->whereRaw($whitelist_whereRaw))
                 ->orderBy('amount_owed', 'desc')->get(),
             'ninjas' => $blacklist_whereRaw ? Miner::whereRaw($blacklist_whereRaw)->limit(100)->get() : [],
             'total_amount_owed' => $total_amount_owed ? $total_amount_owed->total : 0,


### PR DESCRIPTION
fix : 

SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'order by `amount_owed` desc' at line 1 (Connection: mysql, SQL: select * from `miners` where `amount_owed` >= 1 and order by `amount_owed` desc)
