### PR TITLE
Remove 'Available On' date column in public moon listing

### DIFF
--- a/resources/views/moons/public.blade.php
+++ b/resources/views/moons/public.blade.php
@@ -67,7 +67,6 @@
                     <th>Total %</th>
                     <th class="numeric">Rent (Active)</th>
                     <th class="numeric">Rent (Passive)</th>
-                    <th>Available On</th>
                     <th>Status</th>
                 </tr>
             </thead>
@@ -108,11 +107,6 @@
                         </td>
                         <td class="numeric">{{ number_format($moon->monthly_rental_fee) }}</td>
                         <td class="numeric">{{ number_format($moon->monthly_corp_rental_fee) }}</td>
-                        <td>
-                          @if ($renter = $moon->getActiveRenterAttribute())
-                            {{ ($renter->end_date)? $renter->end_date : date('Y-m-d', strtotime($renter->start_date . ' + 183 days')) }}
-                          @endif
-                        </td>
                         <td>
                             {{ match($moon->status_flag) {
                                 \App\Models\Moon::STATUS_ALLIANCE_OWNED => 'Alliance owned',


### PR DESCRIPTION
As per request from Yondu, this column is causing confusion amongst potential renters. The displayed value is based on the moon's current rental contract end date, or start date+183 days if an end date is not set. Due to various changes in the rental programme process, this field isn't used by rental managers and is falling out of date.