### PR TITLE
Sort miners before pagination

### DIFF
--- a/app/Http/Controllers/MinerController.php
+++ b/app/Http/Controllers/MinerController.php
@@ -3,10 +3,12 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Miner;
+use App\Models\Corporation;
 use App\Models\Invoice;
+use App\Models\Miner;
 use App\Models\MiningActivity;
 use App\Models\Payment;
+use Illuminate\Http\Request;
 
 class MinerController extends Controller
 {
@@ -14,10 +16,39 @@ class MinerController extends Controller
     /**
      * List all miners together with their total payments.
      */
-    public function showMiners()
+    public function showMiners(Request $request)
     {
+        $sortColumns = [
+            'name' => 'miners.name',
+            'corporation' => Corporation::select('name')
+                ->whereColumn('corporations.corporation_id', 'miners.corporation_id')
+                ->limit(1),
+            'amount_owed' => 'miners.amount_owed',
+            'total_payments' => Payment::selectRaw('COALESCE(SUM(amount_received), 0)')
+                ->whereColumn('payments.miner_id', 'miners.eve_id'),
+            'latest_mining_activity' => MiningActivity::selectRaw('MAX(created_at)')
+                ->whereColumn('mining_activities.miner_id', 'miners.eve_id'),
+            'latest_invoice' => Invoice::selectRaw('MAX(updated_at)')
+                ->whereColumn('invoices.miner_id', 'miners.eve_id'),
+            'latest_payment' => Payment::selectRaw('MAX(updated_at)')
+                ->whereColumn('payments.miner_id', 'miners.eve_id'),
+        ];
+
+        $sort = $request->query('sort', 'name');
+        $sort = is_string($sort) && array_key_exists($sort, $sortColumns) ? $sort : 'name';
+        $direction = $request->query('direction') === 'desc' ? 'desc' : 'asc';
+
+        $miners = Miner::with('corporation')
+            ->orderBy($sortColumns[$sort], $direction)
+            ->when($sort !== 'name', fn ($query) => $query->orderBy('miners.name'))
+            ->orderBy('miners.eve_id')
+            ->paginate(250)
+            ->withQueryString();
+
         return view('miners.all', [
-            'miners' => Miner::with('corporation')->orderBy('name')->paginate(250),
+            'miners' => $miners,
+            'sort' => $sort,
+            'direction' => $direction,
         ]);
     }
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -860,6 +860,22 @@ table {
   color: #242626;
 }
 
+#miners th.sortable-header {
+  padding: 0;
+}
+
+#miners th.sortable-header a {
+  color: #fff;
+  display: block;
+  padding: 10px;
+}
+
+#miners th.sortable-header a:focus,
+#miners th.sortable-header a:hover {
+  color: #fff;
+  text-decoration: underline;
+}
+
 #miningActivity tr:hover td,
 #miners tr:hover td {
   background: #408077;
@@ -1068,4 +1084,3 @@ ul.pagination .disabled {
 ul.pagination .active {
   color: #408077;
 }
-

--- a/resources/assets/sass/tables.scss
+++ b/resources/assets/sass/tables.scss
@@ -8,6 +8,22 @@ table {
     color: $text;
 }
 
+#miners th.sortable-header {
+    padding: 0;
+
+    a {
+        color: #fff;
+        display: block;
+        padding: 10px;
+
+        &:focus,
+        &:hover {
+            color: #fff;
+            text-decoration: underline;
+        }
+    }
+}
+
 #miningActivity tr:hover td,
 #miners tr:hover td {
     background: $highlight;

--- a/resources/views/miners/_sortable-header.blade.php
+++ b/resources/views/miners/_sortable-header.blade.php
@@ -1,0 +1,18 @@
+@php
+    $isActive = $sort === $column;
+    $nextDirection = $isActive && $direction === 'asc' ? 'desc' : 'asc';
+    $query = array_merge(request()->except(['page', 'sort', 'direction']), [
+        'sort' => $column,
+        'direction' => $nextDirection,
+    ]);
+@endphp
+
+<th class="sortable-header {{ $class ?? '' }}" @if ($isActive) aria-sort="{{ $direction === 'asc' ? 'ascending' : 'descending' }}" @endif>
+    <a href="{{ request()->url() }}?{{ http_build_query($query) }}">
+        {{ $label }}
+        @if ($isActive)
+            <span aria-hidden="true">{{ $direction === 'asc' ? '▲' : '▼' }}</span>
+            <span class="sr-only">, sorted {{ $direction === 'asc' ? 'ascending' : 'descending' }}</span>
+        @endif
+    </a>
+</th>

--- a/resources/views/miners/all.blade.php
+++ b/resources/views/miners/all.blade.php
@@ -9,13 +9,15 @@
         <div class="col-12">
             <table id="miners">
                 <thead>
-                    <th>Miner</th>
-                    <th>Corporation</th>
-                    <th class="numeric">Amount owed</th>
-                    <th class="numeric">Total payments</th>
-                    <th>Last mining date</th>
-                    <th>Last invoice date</th>
-                    <th>Last payment date</th>
+                    <tr>
+                        @include('miners._sortable-header', ['column' => 'name', 'label' => 'Miner'])
+                        @include('miners._sortable-header', ['column' => 'corporation', 'label' => 'Corporation'])
+                        @include('miners._sortable-header', ['column' => 'amount_owed', 'label' => 'Amount owed', 'class' => 'numeric'])
+                        @include('miners._sortable-header', ['column' => 'total_payments', 'label' => 'Total payments', 'class' => 'numeric'])
+                        @include('miners._sortable-header', ['column' => 'latest_mining_activity', 'label' => 'Last mining date'])
+                        @include('miners._sortable-header', ['column' => 'latest_invoice', 'label' => 'Last invoice date'])
+                        @include('miners._sortable-header', ['column' => 'latest_payment', 'label' => 'Last payment date'])
+                    </tr>
                 </thead>
                 <tbody>
                     @foreach ($miners as $miner)
@@ -53,9 +55,10 @@
     <script>
 
         window.addEventListener('load', function () {
-            $('#miners').tablesorter();
-            $('#miners tr').on('click', function () {
-                $(this).find('a')[0].click();
+            $('#miners tbody tr').on('click', function (event) {
+                if ($(event.target).closest('a').length === 0) {
+                    $(this).find('a')[0].click();
+                }
             });
         });
 

--- a/tests/Feature/MinerSortingTest.php
+++ b/tests/Feature/MinerSortingTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\MinerController;
+use App\Models\Miner;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class MinerSortingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'database.default' => 'sqlite',
+            'database.connections.sqlite.database' => ':memory:',
+        ]);
+
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+
+        Schema::create('corporations', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->integer('corporation_id')->unique();
+            $table->string('name');
+        });
+
+        Schema::create('miners', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->integer('eve_id')->unique();
+            $table->integer('corporation_id');
+            $table->string('name');
+            $table->string('avatar')->default('');
+            $table->decimal('amount_owed', 17, 2)->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('payments', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->integer('miner_id');
+            $table->decimal('amount_received', 17, 2);
+            $table->timestamps();
+        });
+
+        Schema::create('invoices', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->integer('miner_id');
+            $table->timestamps();
+        });
+
+        Schema::create('mining_activities', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->integer('miner_id');
+            $table->timestamps();
+        });
+
+        DB::table('corporations')->insert([
+            ['corporation_id' => 10, 'name' => 'Beta Corporation'],
+            ['corporation_id' => 20, 'name' => 'Gamma Corporation'],
+            ['corporation_id' => 30, 'name' => 'Alpha Corporation'],
+        ]);
+
+        Miner::insert([
+            ['eve_id' => 1, 'corporation_id' => 10, 'name' => 'Alpha Miner', 'amount_owed' => 10],
+            ['eve_id' => 2, 'corporation_id' => 20, 'name' => 'Bravo Miner', 'amount_owed' => 20],
+            ['eve_id' => 3, 'corporation_id' => 30, 'name' => 'Charlie Miner', 'amount_owed' => 5],
+        ]);
+
+        DB::table('payments')->insert([
+            ['miner_id' => 1, 'amount_received' => 100, 'created_at' => '2026-01-02', 'updated_at' => '2026-01-02'],
+            ['miner_id' => 2, 'amount_received' => 50, 'created_at' => '2026-01-01', 'updated_at' => '2026-01-01'],
+            ['miner_id' => 3, 'amount_received' => 200, 'created_at' => '2026-01-03', 'updated_at' => '2026-01-03'],
+        ]);
+
+        DB::table('invoices')->insert([
+            ['miner_id' => 1, 'created_at' => '2026-01-01', 'updated_at' => '2026-01-01'],
+            ['miner_id' => 2, 'created_at' => '2026-01-03', 'updated_at' => '2026-01-03'],
+            ['miner_id' => 3, 'created_at' => '2026-01-02', 'updated_at' => '2026-01-02'],
+        ]);
+
+        DB::table('mining_activities')->insert([
+            ['miner_id' => 1, 'created_at' => '2026-01-03', 'updated_at' => '2026-01-03'],
+            ['miner_id' => 2, 'created_at' => '2026-01-01', 'updated_at' => '2026-01-01'],
+            ['miner_id' => 3, 'created_at' => '2026-01-02', 'updated_at' => '2026-01-02'],
+        ]);
+    }
+
+    /**
+     * @dataProvider descendingSorts
+     */
+    public function testItSortsTheCompleteMinerQuery(string $sort, string $expectedFirstMiner): void
+    {
+        $view = (new MinerController())->showMiners(Request::create('/miners', 'GET', [
+            'sort' => $sort,
+            'direction' => 'desc',
+        ]));
+
+        $miners = $view->getData()['miners'];
+
+        $this->assertSame($expectedFirstMiner, $miners->first()->name);
+        $this->assertSame($sort, $view->getData()['sort']);
+        $this->assertSame('desc', $view->getData()['direction']);
+    }
+
+    public static function descendingSorts(): array
+    {
+        return [
+            'miner name' => ['name', 'Charlie Miner'],
+            'corporation' => ['corporation', 'Bravo Miner'],
+            'amount owed' => ['amount_owed', 'Bravo Miner'],
+            'total payments' => ['total_payments', 'Charlie Miner'],
+            'last mining date' => ['latest_mining_activity', 'Alpha Miner'],
+            'last invoice date' => ['latest_invoice', 'Bravo Miner'],
+            'last payment date' => ['latest_payment', 'Charlie Miner'],
+        ];
+    }
+
+    public function testItSortsBeforeApplyingPagination(): void
+    {
+        $additionalMiners = [];
+
+        for ($eveId = 4; $eveId <= 252; $eveId++) {
+            $additionalMiners[] = [
+                'eve_id' => $eveId,
+                'corporation_id' => 10,
+                'name' => sprintf('Miner %03d', $eveId),
+                'amount_owed' => 0,
+            ];
+        }
+
+        $additionalMiners[] = [
+            'eve_id' => 253,
+            'corporation_id' => 10,
+            'name' => 'Zulu Miner',
+            'amount_owed' => 0,
+        ];
+
+        Miner::insert($additionalMiners);
+        DB::table('payments')->insert([
+            'miner_id' => 253,
+            'amount_received' => 10000,
+            'created_at' => '2026-01-04',
+            'updated_at' => '2026-01-04',
+        ]);
+
+        $view = (new MinerController())->showMiners(Request::create('/miners', 'GET', [
+            'sort' => 'total_payments',
+            'direction' => 'desc',
+        ]));
+
+        $miners = $view->getData()['miners'];
+
+        $this->assertSame('Zulu Miner', $miners->first()->name);
+        $this->assertSame(253, $miners->total());
+        $this->assertSame(2, $miners->lastPage());
+    }
+
+    public function testItFallsBackToSafeSortParameters(): void
+    {
+        $view = (new MinerController())->showMiners(Request::create('/miners', 'GET', [
+            'sort' => ['miners.name desc'],
+            'direction' => 'sideways',
+        ]));
+
+        $miners = $view->getData()['miners'];
+
+        $this->assertSame('Alpha Miner', $miners->first()->name);
+        $this->assertSame('name', $view->getData()['sort']);
+        $this->assertSame('asc', $view->getData()['direction']);
+    }
+}


### PR DESCRIPTION
## Summary

- move miner-list sorting into the database query before pagination
- support every visible column with a fixed sort-key whitelist and stable tie-breakers
- preserve sorting across pages and expose accessible, server-rendered sort controls
- replace the page-local tablesorter behavior while retaining row navigation

## Why

The miners table currently applies `tablesorter` in the browser after Laravel has already paginated the query. As a result, only the current 250-row page is sorted and records on later pages can never move into their correct global position.

This change orders the complete query first, then paginates it. Aggregate and latest-date columns use correlated subqueries so the displayed values and database ordering stay aligned.

## User impact

Administrators can sort the entire miner dataset by miner, corporation, amount owed, total payments, latest mining activity, latest invoice, or latest payment. The selected order remains active while paging through results.

## Validation

- PHPUnit: 11 tests, 29 assertions
- regression coverage with 253 miners proves the top result can move from beyond the original first page
- Blade templates compiled successfully
- PHP syntax and Composer manifest validation passed
- production frontend assets compiled successfully

Fixes #61
