### PR TITLE
Show ore types in the user mining log

### DIFF
--- a/app/Http/Controllers/TimerController.php
+++ b/app/Http/Controllers/TimerController.php
@@ -36,7 +36,8 @@ class TimerController extends Controller
             }
 
             // Retrieve all history of the miner's mining, invoices and payments.
-            $mining_activities = MiningActivity::where('miner_id', $miner->eve_id)->get();
+            $mining_activities = MiningActivity::with(['refinery.system', 'type'])
+                ->where('miner_id', $miner->eve_id)->get();
             $invoices = Invoice::where('miner_id', $miner->eve_id)->get();
             $payments = Payment::where('miner_id', $miner->eve_id)->get();
 

--- a/resources/views/blocks/mining-activity-log-entry.blade.php
+++ b/resources/views/blocks/mining-activity-log-entry.blade.php
@@ -1,0 +1,17 @@
+<li>
+    {{ date('Y-m-d H:i', strtotime($event->updated_at)) }} -
+    @if (isset($event->amount))
+        Invoice sent for {{ number_format($event->amount) }} ISK
+    @endif
+    @if (isset($event->quantity))
+        Mining recorded in {{ $event->refinery->system->solarSystemName }}:
+        {{ $event->type?->typeName ?? 'Unknown ore' }}
+        ({{ number_format($event->quantity, 0) }} units)
+        @if (isset($event->tax_amount))
+            ~ {{ number_format($event->tax_amount) }} ISK
+        @endif
+    @endif
+    @if (isset($event->amount_received))
+        Payment received for {{ number_format($event->amount_received) }} ISK
+    @endif
+</li>

--- a/resources/views/timers.blade.php
+++ b/resources/views/timers.blade.php
@@ -133,25 +133,7 @@
             </h2>
             <ul id="activity-log">
                 @foreach ($activity_log as $event)
-                    <li>
-                        {{ date('Y-m-d H:i', strtotime($event->updated_at)) }} -
-                        @if (isset($event->amount))
-                            Invoice sent for {{ number_format($event->amount) }} ISK
-                        @endif
-                        @if (isset($event->quantity))
-                            @php
-                                $refinery = \App\Models\Refinery::where('observer_id', $event->refinery_id)->first();
-                            @endphp
-                            Mining recorded in {{ $refinery->system->solarSystemName }}
-                            ({{ number_format($event->quantity, 0) }} units)
-                            @if (isset($event->tax_amount))
-                                ~ {{ number_format($event->tax_amount) }} ISK
-                            @endif
-                        @endif
-                        @if (isset($event->amount_received))
-                            Payment received for {{ number_format($event->amount_received) }} ISK
-                        @endif
-                    </li>
+                    @include('blocks.mining-activity-log-entry')
                 @endforeach
             </ul>
         </div>

--- a/tests/Feature/MiningActivityLogTest.php
+++ b/tests/Feature/MiningActivityLogTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\MiningActivity;
+use App\Models\Refinery;
+use App\Models\SolarSystem;
+use App\Models\Type;
+use Tests\TestCase;
+
+class MiningActivityLogTest extends TestCase
+{
+    public function testMiningEntriesShowTheirOreType(): void
+    {
+        $activity = new MiningActivity();
+        $activity->quantity = 1250;
+        $activity->updated_at = '2026-08-07 12:30:00';
+
+        $type = new Type();
+        $type->typeName = 'Compressed Veldspar';
+        $activity->setRelation('type', $type);
+
+        $refinery = new Refinery();
+        $system = new SolarSystem();
+        $system->solarSystemName = 'F7C-H0';
+        $refinery->setRelation('system', $system);
+        $activity->setRelation('refinery', $refinery);
+
+        $html = view('blocks.mining-activity-log-entry', ['event' => $activity])->render();
+
+        $this->assertStringContainsString('Mining recorded in F7C-H0:', $html);
+        $this->assertStringContainsString('Compressed Veldspar', $html);
+        $this->assertStringContainsString('1,250 units', $html);
+    }
+}


### PR DESCRIPTION
## Summary

- show the ore type on every mining entry in the signed-in user's activity log
- eager-load ore type, refinery, and system data for mining activity rows
- cover the rendered ore name, system, and quantity with a focused view test

## Why

The user-facing mining log showed only the system, timestamp, and quantity. Entries for different ores mined in the same window therefore looked like duplicates. Including the related EVE type name makes each row distinguishable.

## Validation

- `vendor/bin/phpunit` (3 tests, 5 assertions; temporary test app key supplied)
- `php artisan view:cache` (temporary test app key supplied)
- `composer validate --strict`
- PHP syntax checks for the changed PHP files

Fixes #62
