### PR TITLE
Add search to the miners list

### DIFF
--- a/app/Http/Controllers/MinerController.php
+++ b/app/Http/Controllers/MinerController.php
@@ -7,6 +7,7 @@ use App\Models\Miner;
 use App\Models\Invoice;
 use App\Models\MiningActivity;
 use App\Models\Payment;
+use Illuminate\Http\Request;
 
 class MinerController extends Controller
 {
@@ -14,10 +15,27 @@ class MinerController extends Controller
     /**
      * List all miners together with their total payments.
      */
-    public function showMiners()
+    public function showMiners(Request $request)
     {
+        $search = trim((string) $request->query('search', ''));
+
+        $miners = Miner::with('corporation')
+            ->when($search !== '', function ($query) use ($search) {
+                $query->where(function ($query) use ($search) {
+                    $query->where('name', 'like', '%' . $search . '%');
+
+                    if (ctype_digit($search)) {
+                        $query->orWhere('eve_id', $search);
+                    }
+                });
+            })
+            ->orderBy('name')
+            ->paginate(250)
+            ->withQueryString();
+
         return view('miners.all', [
-            'miners' => Miner::with('corporation')->orderBy('name')->paginate(250),
+            'miners' => $miners,
+            'search' => $search,
         ]);
     }
 

--- a/resources/views/miners/all.blade.php
+++ b/resources/views/miners/all.blade.php
@@ -7,6 +7,20 @@
     <div class="row">
 
         <div class="col-12">
+            <form method="get" action="/miners" class="external-filters">
+                <label for="miner-search">Search miners</label>
+                <input
+                    type="search"
+                    id="miner-search"
+                    name="search"
+                    value="{{ $search }}"
+                    placeholder="Name or character ID"
+                >
+                <button type="submit">Search</button>
+                @if ($search !== '')
+                    <a href="/miners">Clear</a>
+                @endif
+            </form>
             <table id="miners">
                 <thead>
                     <th>Miner</th>
@@ -18,7 +32,7 @@
                     <th>Last payment date</th>
                 </thead>
                 <tbody>
-                    @foreach ($miners as $miner)
+                    @forelse ($miners as $miner)
                         <tr>
                             <td><a href="/miners/{{ $miner->eve_id }}">{{ $miner->name }}</a></td>
                             <td>
@@ -42,7 +56,11 @@
                                 @endif
                             </td>
                         </tr>
-                    @endforeach
+                    @empty
+                        <tr>
+                            <td colspan="7">No miners match your search.</td>
+                        </tr>
+                    @endforelse
                 </tbody>
             </table>
             {{ $miners->links() }}

--- a/tests/Feature/MinerSearchTest.php
+++ b/tests/Feature/MinerSearchTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\MinerController;
+use App\Models\Miner;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class MinerSearchTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'database.default' => 'sqlite',
+            'database.connections.sqlite.database' => ':memory:',
+        ]);
+
+        DB::purge('sqlite');
+        DB::setDefaultConnection('sqlite');
+
+        Schema::create('corporations', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->integer('corporation_id')->unique();
+            $table->string('name');
+        });
+
+        Schema::create('miners', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->integer('eve_id')->unique();
+            $table->integer('corporation_id');
+            $table->string('name');
+            $table->string('avatar')->default('');
+            $table->decimal('amount_owed', 17, 2)->default(0);
+            $table->timestamps();
+        });
+
+        DB::table('corporations')->insert([
+            'corporation_id' => 10,
+            'name' => 'Test Corporation',
+        ]);
+
+        Miner::insert([
+            ['eve_id' => 1001, 'corporation_id' => 10, 'name' => 'Alpha Miner'],
+            ['eve_id' => 1002, 'corporation_id' => 10, 'name' => 'Bravo Miner'],
+            ['eve_id' => 1003, 'corporation_id' => 10, 'name' => 'Another Alpha'],
+        ]);
+    }
+
+    public function testItSearchesMinersByPartialName(): void
+    {
+        $view = $this->showMiners(['search' => 'Alpha']);
+
+        $this->assertSame(
+            ['Alpha Miner', 'Another Alpha'],
+            $view->getData()['miners']->pluck('name')->all()
+        );
+        $this->assertSame('Alpha', $view->getData()['search']);
+    }
+
+    public function testItSearchesMinersByExactCharacterId(): void
+    {
+        $view = $this->showMiners(['search' => '1002']);
+
+        $this->assertSame(
+            ['Bravo Miner'],
+            $view->getData()['miners']->pluck('name')->all()
+        );
+    }
+
+    public function testItPreservesSearchWhenPaginating(): void
+    {
+        $view = $this->showMiners(['search' => 'Miner']);
+
+        $this->assertStringContainsString('search=Miner', $view->getData()['miners']->url(2));
+    }
+
+    private function showMiners(array $query)
+    {
+        $request = Request::create('/miners', 'GET', $query);
+        $this->app->instance('request', $request);
+
+        return (new MinerController())->showMiners($request);
+    }
+}


### PR DESCRIPTION
## Summary

- add a server-side miner search by partial character name or exact character ID
- keep the active search when moving between result pages
- add an accessible search and clear control with an explicit empty-result message
- cover name, character ID, and pagination behavior with focused feature tests

## Why

The miners list can contain more than one page of characters, so finding a specific miner currently requires paging manually or editing the details URL with a known character ID. Filtering the database query before pagination makes the requested miner directly accessible.

## Validation

- `vendor/bin/phpunit tests/Feature/MinerSearchTest.php` (3 tests, 4 assertions)
- `vendor/bin/phpunit` (5 tests, 6 assertions)
- `php artisan view:cache`
- `composer validate --strict`
- PHP syntax checks for the changed PHP files
- `git diff --check`

Fixes #63
